### PR TITLE
Update dependency to H5P.Question

### DIFF
--- a/library.json
+++ b/library.json
@@ -3,7 +3,7 @@
   "description": "Create a Quiz on wich the users click on a leaflet map to answer the questions.",
   "majorVersion": 1,
   "minorVersion": 1,
-  "patchVersion": 9,
+  "patchVersion": 10,
   "runnable": 1,
   "fullscreen": 0,
   "embedTypes": [
@@ -22,7 +22,7 @@
     },
     {
       "path": "css/GeoQuiz.css"
-    }   
+    }
   ],
   "preloadedJs": [
     {
@@ -41,7 +41,7 @@
     {
       "machineName": "H5P.Question",
       "majorVersion": 1,
-      "minorVersion": 3
+      "minorVersion": 4
     }
   ],
   "editorDependencies": [


### PR DESCRIPTION
GeoQuiz would be the only content type that still references version
1.3 of H5P.Question (Essay does, too, in the released version, but
the repository is up-to-date already), thus blocking the old library
from being removed.